### PR TITLE
Added `Readers` module to `checkpoint`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+.vscode
+.idea

--- a/checkpoint/io.py
+++ b/checkpoint/io.py
@@ -142,7 +142,7 @@ class IO:
 
     def get_file_extension(self, file_path):
         """Get the extension from the file.
-        
+
         Parameters
         ----------
         file_path: str

--- a/checkpoint/io.py
+++ b/checkpoint/io.py
@@ -3,7 +3,6 @@ from os.path import join as pjoin
 from os.path import isdir
 
 
-
 class IO:
     """Class to perform Input/Output opreations.
 
@@ -140,6 +139,22 @@ class IO:
             )
 
         return open(file, mode)
+
+    def get_file_extension(self, file_path):
+        """Get the extension from the file.
+        
+        Parameters
+        ----------
+        file_path: str
+            Path to the file
+        """
+        if not os.path.isfile(file_path):
+            raise IOError(
+                f'{file_path} is not a valid file'
+            )
+
+        _file = os.path.basename(file_path)
+        return _file.split('.')[-1]
 
     @property
     def path(self):

--- a/checkpoint/readers.py
+++ b/checkpoint/readers.py
@@ -123,7 +123,7 @@ class TextReader(Reader):
 
     def _validate_extensions(self, extensions):
         """Validate if the extensions work with the current reader.
-        
+
         Parameters
         ----------
         extensions: list

--- a/checkpoint/readers.py
+++ b/checkpoint/readers.py
@@ -101,7 +101,7 @@ class TextReader(Reader):
         self.additional_extensions = additional_extensions or []
         super(TextReader, self).__init__(['txt', 'md', 'rst', 'py',
                                           'html', 'css', 'js', 'json'])
-        
+
         _invalid_idxs = self.validate_extensions(self.additional_extensions)
         for idx in _invalid_idxs:
             self.additional_extensions.pop(idx)

--- a/checkpoint/readers.py
+++ b/checkpoint/readers.py
@@ -1,0 +1,153 @@
+"""Module that provides readers for different file extensions."""
+import os
+import abc
+from tempfile import TemporaryDirectory as InTemporaryDirectory
+from checkpoint.io import IO
+
+
+class Reader(abc.ABC):
+    """Umbrella for all reader classes."""
+    def __init__(self, valid_extensions=None):
+        """Initialize the Reader class.
+
+        Parameters
+        ----------
+        valid_extensions: list
+            List of valid extensions for the reader
+        """
+        self._io = IO()
+        self.valid_extensions = valid_extensions or []
+
+    @abc.abstractmethod
+    def _read(self, file_path):
+        """Read the content of the file.
+
+        Parameters
+        ----------
+        file_path: str
+            Path to the file that is to be read
+
+        Returns
+        -------
+        content: str
+            Content of the file
+        """
+        msg = "This method must be implemented by the child class."
+        raise NotImplementedError(msg)
+
+    @abc.abstractmethod
+    def _validate_extensions(self, extensions):
+        """Validate if the additional extensions are valid.
+
+        Parameters
+        ----------
+        extensions: list
+            List of extensions to be validated
+
+        Returns
+        -------
+        is_valid: bool
+            True if the extensions are valid, False otherwise
+        """
+        msg = "This method must be implemented by the child class."
+        raise NotImplementedError(msg)
+
+    def read(self, file_path):
+        """Read the content of the file.
+
+        Parameters
+        ----------
+        file_path: str
+            Path to the file that is to be read
+
+        Returns
+        -------
+        content: str
+            Content of the file
+        """
+        _ext = self._io.get_file_extension(file_path)
+
+        if _ext not in self.valid_extensions:
+            raise ValueError(f"Invalid file extension: {_ext}")
+        else:
+            return self._read(file_path)
+
+    def validate_extensions(self, extensions):
+        """Validate if the additional extensions are valid.
+
+        Parameters
+        ----------
+        extensions: list
+            List of extensions to be validated
+
+        Returns
+        -------
+        is_valid: bool
+            True if the extensions are valid, False otherwise
+        """
+        return self._validate_extensions(extensions)
+
+
+class TextReader(Reader):
+    """Class to read text files."""
+    def __init__(self, additional_extensions=None):
+        """Initilaize the TextReader class.
+
+        Parameters
+        ----------
+        additional_extensions: list
+            List of additional extensions that are valid for the reader
+        """
+        self.valid_extensions = ['txt', 'md', 'rst', 'py',
+                                 'html', 'css', 'js', 'json']
+
+        self.additional_extensions = additional_extensions or []
+        if self.validate_extensions(self.additional_extensions):
+            self.valid_extensions.extend(self.additional_extensions)
+
+        super(TextReader, self).__init__(self.valid_extensions)
+
+    def _read(self, file_path):
+        """Read the content of the file.
+
+        Parameters
+        ----------
+        file_path: str
+            Path to the file that is to be read
+
+        Returns
+        -------
+        content: str
+            Content of the file
+        """
+        with open(file_path, 'r') as f:
+            content = f.read()
+
+        return content
+
+    def _validate_extensions(self, extensions):
+        """Validate if the extensions work with the current reader.
+
+        Parameters
+        ----------
+        extensions: list
+            List of extensions to be validated
+
+        Returns
+        -------
+        valid: bool
+            True if the extensions are valid, False otherwise
+        """
+        with InTemporaryDirectory() as tdir:
+            for extension in extensions:
+                file_name = f"file.{extension}"
+                file_path = os.path.join(tdir, file_name)
+                with open(file_path, 'w+') as f:
+                    f.write("")
+
+                try:
+                    self._read(file_path)
+                except Exception as e:
+                    return False
+
+        return True

--- a/checkpoint/readers.py
+++ b/checkpoint/readers.py
@@ -102,10 +102,7 @@ class TextReader(Reader):
         super(TextReader, self).__init__(['txt', 'md', 'rst', 'py',
                                           'html', 'css', 'js', 'json'])
 
-        _invalid_idxs = self.validate_extensions(self.additional_extensions)
-        for idx in _invalid_idxs:
-            self.additional_extensions.pop(idx)
-
+        self.validate_extensions(self.additional_extensions)
         self.valid_extensions.extend(self.additional_extensions)
 
     def _read(self, file_path):
@@ -126,16 +123,11 @@ class TextReader(Reader):
 
     def _validate_extensions(self, extensions):
         """Validate if the extensions work with the current reader.
-
+        
         Parameters
         ----------
         extensions: list
             List of extensions to be validated
-
-        Returns
-        -------
-        invalid_idxs: list
-            List of indices of invalid extensions
         """
         invalid_idxs = []
         with InTemporaryDirectory() as tdir:
@@ -150,4 +142,5 @@ class TextReader(Reader):
                 except Exception as e:
                     invalid_idxs.append(idx)
 
-        return invalid_idxs
+        for idx in invalid_idxs:
+            extensions.pop(idx)

--- a/checkpoint/tests/test_io.py
+++ b/checkpoint/tests/test_io.py
@@ -22,9 +22,12 @@ def test_io():
         a_io = io.IO(path=tdir, mode='a')
         a_io.write(file=pjoin(tdir, 'temp.txt'), mode='x', content='Temporary File')
         ext = a_io.get_file_extension(pjoin(tdir, 'temp.txt'))
+        
+        with npt.assert_raises(OSError):
+            a_io.get_file_extension(pjoin(tdir, 'invalid.txt'))
         npt.assert_equal(ext, 'txt')
-        content = a_io.read(file=pjoin(tdir, 'temp.txt'))
 
+        content = a_io.read(file=pjoin(tdir, 'temp.txt'))
         npt.assert_equal(content, 'Temporary File')
         file_path = pjoin(tdir, 'temp.txt')
 

--- a/checkpoint/tests/test_io.py
+++ b/checkpoint/tests/test_io.py
@@ -22,7 +22,7 @@ def test_io():
         a_io = io.IO(path=tdir, mode='a')
         a_io.write(file=pjoin(tdir, 'temp.txt'), mode='x', content='Temporary File')
         ext = a_io.get_file_extension(pjoin(tdir, 'temp.txt'))
-        
+
         with npt.assert_raises(OSError):
             a_io.get_file_extension(pjoin(tdir, 'invalid.txt'))
         npt.assert_equal(ext, 'txt')

--- a/checkpoint/tests/test_io.py
+++ b/checkpoint/tests/test_io.py
@@ -21,6 +21,8 @@ def test_io():
 
         a_io = io.IO(path=tdir, mode='a')
         a_io.write(file=pjoin(tdir, 'temp.txt'), mode='x', content='Temporary File')
+        ext = a_io.get_file_extension(pjoin(tdir, 'temp.txt'))
+        npt.assert_equal(ext, 'txt')
         content = a_io.read(file=pjoin(tdir, 'temp.txt'))
 
         npt.assert_equal(content, 'Temporary File')

--- a/checkpoint/tests/test_readers.py
+++ b/checkpoint/tests/test_readers.py
@@ -38,7 +38,7 @@ def test_reader():
 
 
 def test_text_reader():
-    simple_text_reader = readers.TextReader(additional_extensions=['txt'])
+    simple_text_reader = readers.TextReader(additional_extensions=['json'])
 
     with InTemporaryDirectory() as tdir:
         invalid_file = pjoin(tdir, 'invalid.extension')
@@ -54,6 +54,6 @@ def test_text_reader():
         npt.assert_equal(simple_text_reader.read(valid_file), 'Test Content')
 
         valid_extensions = ['txt', 'log']
-        invalid_idxs = simple_text_reader.validate_extensions(valid_extensions)
+        simple_text_reader.validate_extensions(valid_extensions)
 
-        npt.assert_equal(invalid_idxs, [])
+        npt.assert_equal(valid_extensions, ['txt', 'log'])

--- a/checkpoint/tests/test_readers.py
+++ b/checkpoint/tests/test_readers.py
@@ -1,0 +1,59 @@
+import os
+from os.path import join as pjoin
+import numpy.testing as npt
+from tempfile import TemporaryDirectory as InTemporaryDirectory
+
+from checkpoint import readers
+from checkpoint.io import IO
+
+
+def test_reader():
+    class SimpleReader(readers.Reader):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def _read(self, *args, **kwargs):
+            return 'test'
+
+        def _validate_extensions(self, *args, **kwargs):
+            return []
+
+    core_reader = SimpleReader(valid_extensions=['txt'])
+
+    with InTemporaryDirectory() as tdir:
+        io = IO(tdir)
+        invalid_file = pjoin(tdir, 'invalid.extension')
+        io.write(invalid_file, 'w+', 'Test Content')
+
+        with npt.assert_raises(ValueError):
+            core_reader.read(invalid_file)
+
+        valid_file = pjoin(tdir, 'valid.txt')
+        io.write(valid_file, 'w+', 'Test Content')
+
+        npt.assert_equal(core_reader.read(valid_file), 'test')
+
+        extensions = ['txt', 'log']
+        npt.assert_equal(core_reader.validate_extensions(extensions), [])
+
+
+def test_text_reader():
+    simple_text_reader = readers.TextReader(additional_extensions=['txt'])
+
+    with InTemporaryDirectory() as tdir:
+        invalid_file = pjoin(tdir, 'invalid.extension')
+        io = IO(tdir)
+        io.write(invalid_file, 'w+', 'Test Content')
+
+        with npt.assert_raises(ValueError):
+            simple_text_reader.read(invalid_file)
+
+        valid_file = pjoin(tdir, 'valid.txt')
+        io.write(valid_file, 'w+', 'Test Content')
+
+        npt.assert_equal(simple_text_reader.read(valid_file), 'Test Content')
+
+        valid_extensions = ['txt', 'log']
+        invalid_idxs = simple_text_reader.validate_extensions(valid_extensions)
+
+        npt.assert_equal(invalid_idxs, [])


### PR DESCRIPTION
This PR adds a `readers` module to checkpoint. This module provides readers for different extensions. Below is an example:-

```python
from checkpoint.readers import TextReader

txt_reader = TextReader(additional_extensions=['log'])

content = txt_reader.read('session.log')
```